### PR TITLE
feat: add marketing landing page

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CoreoForm</title>
+  </head>
+  <body>
+    <h1>CoreoForm</h1>
+    <p>Organize suas coreografias de forma simples e colaborativa.</p>
+    <button id="btn-entrar">Entrar</button>
+    <script type="module" src="/src/landing.ts"></script>
+  </body>
+</html>

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,10 +7,12 @@ import { btnLogin, btnLogout, userBadgeEl } from './dom';
 let _user: User | null = null;
 export function getUser(){ return _user; }
 
+export async function signIn() {
+  try { await signInWithPopup(auth, provider); } catch (e) { console.error(e); }
+}
+
 export function initAuthUI() {
-  btnLogin?.addEventListener('click', async () => {
-    try { await signInWithPopup(auth, provider); } catch (e) { console.error(e); }
-  });
+  btnLogin?.addEventListener('click', signIn);
 
   btnLogout?.addEventListener('click', async () => {
     try { await signOut(auth); } catch (e) { console.error(e); }

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -1,0 +1,12 @@
+import { signIn } from './auth';
+
+const btn = document.getElementById('btn-entrar');
+
+btn?.addEventListener('click', async () => {
+  try {
+    await signIn();
+    window.location.href = 'index.html';
+  } catch (e) {
+    console.error(e);
+  }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,15 @@
 
 import { defineConfig } from 'vite'
+import { resolve } from 'path'
 
 export default defineConfig({
-  server: { port: 5173, host: true }
+  server: { port: 5173, host: true },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        landing: resolve(__dirname, 'landing.html')
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- create landing page with marketing content and login button
- expose signIn helper and wire up new landing entry
- include landing page in Vite build inputs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: src/record.ts(26,26): argument of type 'MediaStream | null' is not assignable to parameter of type 'MediaStream')*

------
https://chatgpt.com/codex/tasks/task_e_68c80e7a4e30832699c8a11fd83d6d59