### PR TITLE
Include landing page in Vite build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,15 @@
 
 import { defineConfig } from 'vite'
+import { resolve } from 'path'
 
 export default defineConfig({
-  server: { port: 5173, host: true }
+  server: { port: 5173, host: true },
+  build: {
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'index.html'),
+        landing: resolve(__dirname, 'landing.html')
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- Configure Vite to build both the login landing page and the main editor

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c81d7f50f48326aa448bf7b5ffb070