### PR TITLE
Add Pina branding to product UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,12 @@
       input[type="file"] { display: none; }
       .barra-superior { padding: 10px 16px; background-color: var(--cor-fundo-secundaria); border-bottom: 1px solid var(--cor-borda); display: flex; gap: 12px; align-items: center; justify-content: space-between; }
       .left, .right { display: flex; gap: 8px; align-items: center; }
+      .left { gap: 12px; }
+      .logo-pina {
+        height: 34px;
+        width: auto;
+        display: block;
+      }
       .container-principal { display: flex; flex: 1; min-height: 0; }
       .barra-lateral { width: 280px; background: var(--cor-fundo-secundaria); border-right: 1px solid var(--cor-borda); padding: 16px; display: flex; flex-direction: column; gap: 8px; }
       .palco-wrapper { flex: 1; display: flex; flex-direction: column; align-items: center; }
@@ -393,6 +399,7 @@
   <body>
     <header class="barra-superior">
       <div class="left">
+        <img src="/assets/pina-logo-mono.svg" alt="Pina" class="logo-pina" />
         <h1 id="titulo-projeto" style="font-size: 1.05em; margin: 0;">Coreografia</h1>
         <button id="btn-exportar">Exportar JSON</button>
         <button id="btn-importar">Importar JSON</button>

--- a/landing.html
+++ b/landing.html
@@ -111,21 +111,22 @@
       }
 
       .brand {
-        display: flex;
+        display: inline-flex;
         align-items: center;
-        gap: 14px;
+        gap: 16px;
+        color: inherit;
+        text-decoration: none;
+        transition: opacity 0.2s ease;
       }
 
-      .brand-mark {
-        width: 48px;
-        height: 48px;
-        border-radius: 16px;
-        background: linear-gradient(145deg, rgba(244, 114, 182, 0.28), rgba(168, 85, 247, 0.35));
-        border: 1px solid rgba(244, 114, 182, 0.45);
-        display: grid;
-        place-items: center;
-        font-weight: 700;
-        letter-spacing: 0.08em;
+      .brand:hover {
+        opacity: 0.9;
+      }
+
+      .brand-logo {
+        height: 52px;
+        width: auto;
+        display: block;
       }
 
       .brand strong {
@@ -897,13 +898,13 @@
     <div class="landing">
       <header class="top-nav">
         <div class="wrapper nav-wrapper">
-          <div class="brand">
-            <span class="brand-mark">CF</span>
+          <a class="brand" href="#inicio" aria-label="Pina — CoreoForm Pina Beta">
+            <img src="/assets/pina-logo-color.svg" alt="Pina" class="brand-logo" />
             <div>
               <strong>CoreoForm</strong>
               <small>Pina Beta</small>
             </div>
-          </div>
+          </a>
           <nav class="nav-links">
             <a href="#recursos">Recursos</a>
             <a href="#fluxo">Fluxo</a>

--- a/public/assets/pina-logo-color.svg
+++ b/public/assets/pina-logo-color.svg
@@ -1,0 +1,31 @@
+<svg width="240" height="80" viewBox="0 0 240 80" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Pina logotipo colorido</title>
+  <desc id="desc">Marca tipográfica com P geométrico em gradiente azul e rosa e o lettering manuscrito “ina”.</desc>
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Pacifico&display=swap');
+    </style>
+    <linearGradient id="grad-brand" x1="12" y1="8" x2="80" y2="72" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38BDF8" />
+      <stop offset="1" stop-color="#F472B6" />
+    </linearGradient>
+    <linearGradient id="grad-letter" x1="80" y1="26" x2="224" y2="74" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#22D3EE" />
+      <stop offset="1" stop-color="#EC4899" />
+    </linearGradient>
+    <filter id="shadow" x="0" y="0" width="120" height="96" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="4" />
+      <feGaussianBlur stdDeviation="6" result="blur" />
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.18 0" />
+      <feBlend in="SourceGraphic" result="shape" />
+    </filter>
+  </defs>
+  <g filter="url(#shadow)">
+    <path fill="url(#grad-brand)" fill-rule="evenodd" clip-rule="evenodd"
+      d="M18 8h32c18 0 34 16 34 34s-16 34-34 34H18c-3.866 0-6-2.134-6-6V14c0-3.866 2.134-6 6-6Zm10 18c-3.314 0-6 2.686-6 6v20c0 3.314 2.686 6 6 6h18c9.941 0 18-8.059 18-18s-8.059-18-18-18H28Z" />
+  </g>
+  <text x="82" y="54" fill="url(#grad-letter)" font-size="44" letter-spacing="0.04em"
+    style="font-family: 'Pacifico', 'Brush Script MT', 'Comic Sans MS', cursive; font-weight: 400;">
+    ina
+  </text>
+</svg>

--- a/public/assets/pina-logo-mono.svg
+++ b/public/assets/pina-logo-mono.svg
@@ -1,0 +1,15 @@
+<svg width="220" height="72" viewBox="0 0 220 72" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Pina logotipo monocromático</title>
+  <desc id="desc">Versão linear do logotipo Pina em uma única cor clara.</desc>
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Pacifico&display=swap');
+    </style>
+  </defs>
+  <path fill="#F8FAFC" fill-rule="evenodd" clip-rule="evenodd"
+    d="M16 6h30c17.673 0 32 14.327 32 32S63.673 70 46 70H16c-3.866 0-6-2.134-6-6V12c0-3.866 2.134-6 6-6Zm9 18c-3.314 0-6 2.686-6 6v18c0 3.314 2.686 6 6 6h16c8.837 0 16-7.163 16-16s-7.163-16-16-16H25Z" />
+  <text x="78" y="50" fill="#F8FAFC" font-size="40" letter-spacing="0.04em"
+    style="font-family: 'Pacifico', 'Brush Script MT', 'Comic Sans MS', cursive; font-weight: 400;">
+    ina
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- add the official Pina color and monochrome SVG assets under public/assets
- show the monochrome logotype in the main editor header and adjust spacing
- update the landing navigation brand block to use the color logo and hover styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca00426ae483269cc66d4c291ad242