### PR TITLE
Add email/password authentication options

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -814,6 +814,245 @@
         text-align: center;
       }
 
+      body.auth-modal-open {
+        overflow: hidden;
+      }
+
+      .auth-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(4, 6, 15, 0.72);
+        backdrop-filter: blur(14px);
+        z-index: 50;
+      }
+
+      .auth-backdrop[hidden] {
+        display: none;
+      }
+
+      .auth-modal {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: min(420px, 92vw);
+        background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(8, 12, 29, 0.95));
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        border-radius: var(--radius-lg);
+        padding: 36px;
+        box-shadow: 0 40px 90px -48px rgba(4, 6, 15, 0.9);
+        z-index: 60;
+        display: flex;
+        flex-direction: column;
+        gap: 22px;
+        color: var(--color-text);
+        backdrop-filter: blur(20px);
+        isolation: isolate;
+      }
+
+      .auth-modal[hidden] {
+        display: none;
+      }
+
+      .auth-modal::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: radial-gradient(circle at top, rgba(244, 114, 182, 0.18), transparent 65%);
+        opacity: 0.6;
+        pointer-events: none;
+      }
+
+      .auth-modal > * {
+        position: relative;
+        z-index: 1;
+      }
+
+      .auth-close {
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        width: 36px;
+        height: 36px;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.32);
+        background: rgba(15, 23, 42, 0.82);
+        color: var(--color-text);
+        font-size: 1.1rem;
+        line-height: 1;
+        cursor: pointer;
+        display: grid;
+        place-items: center;
+        transition: background 0.2s ease, border 0.2s ease, transform 0.2s ease;
+      }
+
+      .auth-close:hover {
+        border-color: rgba(148, 163, 184, 0.55);
+        background: rgba(30, 41, 59, 0.9);
+        transform: translateY(-1px);
+      }
+
+      .auth-header h2 {
+        margin: 0 0 6px;
+        font-size: 1.6rem;
+      }
+
+      .auth-header p {
+        margin: 0;
+        color: var(--color-muted);
+        font-size: 0.98rem;
+      }
+
+      .auth-tabs {
+        display: inline-flex;
+        gap: 8px;
+        padding: 6px;
+        border-radius: 999px;
+        background: rgba(15, 23, 42, 0.72);
+        border: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      .auth-tab {
+        border: none;
+        background: transparent;
+        color: var(--color-muted);
+        padding: 10px 18px;
+        border-radius: 999px;
+        font-weight: 600;
+        font-size: 0.95rem;
+        cursor: pointer;
+        transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+      }
+
+      .auth-tab:hover {
+        color: var(--color-text);
+      }
+
+      .auth-tab.is-active {
+        background: linear-gradient(135deg, rgba(244, 114, 182, 0.28), rgba(56, 189, 248, 0.28));
+        color: var(--color-text);
+        transform: translateY(-1px);
+      }
+
+      .auth-body {
+        display: grid;
+        gap: 18px;
+      }
+
+      .auth-section[hidden] {
+        display: none !important;
+      }
+
+      .auth-form {
+        display: grid;
+        gap: 18px;
+      }
+
+      .auth-field {
+        display: grid;
+        gap: 6px;
+      }
+
+      .auth-field span {
+        font-weight: 600;
+        font-size: 0.92rem;
+        color: var(--color-muted);
+      }
+
+      .auth-field input {
+        background: rgba(15, 23, 42, 0.85);
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        border-radius: var(--radius-sm);
+        padding: 12px 14px;
+        font-size: 0.95rem;
+        color: var(--color-text);
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .auth-field input::placeholder {
+        color: rgba(226, 232, 240, 0.5);
+      }
+
+      .auth-field input:focus {
+        outline: none;
+        border-color: rgba(56, 189, 248, 0.6);
+        box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+      }
+
+      .auth-helper {
+        font-size: 0.78rem;
+        color: rgba(226, 232, 240, 0.65);
+      }
+
+      .auth-error {
+        margin: 0;
+        font-size: 0.85rem;
+        color: #fca5a5;
+        min-height: 1.1em;
+      }
+
+      .auth-error[hidden] {
+        display: none;
+      }
+
+      .auth-divider {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 0.85rem;
+        color: var(--color-muted);
+      }
+
+      .auth-divider::before,
+      .auth-divider::after {
+        content: '';
+        flex: 1;
+        height: 1px;
+        background: rgba(148, 163, 184, 0.28);
+      }
+
+      .auth-modal .btn {
+        width: 100%;
+        justify-content: center;
+      }
+
+      .auth-modal .btn .btn-icon {
+        background: rgba(15, 23, 42, 0.55);
+      }
+
+      .btn-google {
+        background: rgba(15, 23, 42, 0.85);
+        border: 1px solid rgba(148, 163, 184, 0.32);
+      }
+
+      .btn-google:hover {
+        border-color: rgba(148, 163, 184, 0.55);
+        background: rgba(30, 41, 59, 0.9);
+      }
+
+      .auth-modal .btn[data-loading='true'] {
+        opacity: 0.72;
+        cursor: progress;
+      }
+
+      .auth-footer {
+        margin: 0;
+        font-size: 0.75rem;
+        color: rgba(226, 232, 240, 0.6);
+        text-align: center;
+      }
+
+      @media (max-width: 520px) {
+        .auth-modal {
+          padding: 28px 24px;
+        }
+
+        .auth-header h2 {
+          font-size: 1.4rem;
+        }
+      }
+
       @media (max-width: 1024px) {
         nav.nav-links {
           display: none;
@@ -913,7 +1152,7 @@
           <div class="nav-actions">
             <span class="nav-link-light">Convide o elenco para testar</span>
             <button class="btn btn-primary" type="button" data-login-button>
-              <span>Entrar agora</span>
+              <span>Entrar ou criar conta</span>
               <span class="btn-icon">→</span>
             </button>
           </div>
@@ -932,7 +1171,7 @@
               </p>
               <div class="hero-buttons">
                 <button class="btn btn-primary" type="button" data-login-button>
-                  <span>Entrar com Google</span>
+                  <span>Entrar ou criar conta</span>
                   <span class="btn-icon">⟶</span>
                 </button>
                 <a class="btn btn-ghost" href="#recursos">
@@ -1176,11 +1415,11 @@
             <div class="cta-card">
               <h3>Experimente o CoreoForm Pina Beta com seu elenco.</h3>
               <p>
-                O acesso é liberado para equipes convidadas. Entre com sua conta Google para sincronizar projetos, importar áudio e
-                compartilhar formações com o time em segundos.
+                O acesso é liberado para equipes convidadas. Use sua conta Google ou crie um cadastro com email e senha para
+                sincronizar projetos, importar áudio e compartilhar formações com o time em segundos.
               </p>
               <button class="btn btn-primary" type="button" data-login-button>
-                <span>Entrar e começar agora</span>
+                <span>Entrar ou criar conta</span>
                 <span class="btn-icon">→</span>
               </button>
             </div>
@@ -1191,6 +1430,118 @@
       <footer>
         © <span id="year">2024</span> CoreoForm Pina Beta • Construído para diretores, ensaiadores e bailarinos.
       </footer>
+    </div>
+
+    <div class="auth-backdrop" data-login-backdrop hidden></div>
+    <div
+      class="auth-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="auth-modal-title"
+      aria-hidden="true"
+      data-login-modal
+      hidden
+    >
+      <button class="auth-close" type="button" aria-label="Fechar modal de autenticação" data-close-login-modal>
+        &times;
+      </button>
+      <div class="auth-header">
+        <h2 id="auth-modal-title">Acesse o CoreoForm</h2>
+        <p>Use sua conta Google ou crie um cadastro com email e senha para começar.</p>
+      </div>
+      <div class="auth-tabs" role="tablist">
+        <button
+          class="auth-tab is-active"
+          type="button"
+          role="tab"
+          aria-selected="true"
+          id="auth-tab-login"
+          aria-controls="auth-panel-login"
+          data-auth-mode="login"
+        >
+          Entrar
+        </button>
+        <button
+          class="auth-tab"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          id="auth-tab-register"
+          aria-controls="auth-panel-register"
+          data-auth-mode="register"
+        >
+          Criar conta
+        </button>
+      </div>
+      <div class="auth-body">
+        <div
+          class="auth-section"
+          data-auth-section="login"
+          role="tabpanel"
+          id="auth-panel-login"
+          aria-labelledby="auth-tab-login"
+        >
+          <form class="auth-form" data-auth-form="login">
+            <label class="auth-field">
+              <span>Email</span>
+              <input type="email" name="email" autocomplete="email" placeholder="nome@exemplo.com" required />
+            </label>
+            <label class="auth-field">
+              <span>Senha</span>
+              <input
+                type="password"
+                name="password"
+                autocomplete="current-password"
+                minlength="6"
+                required
+                placeholder="Sua senha"
+              />
+            </label>
+            <button class="btn btn-primary" type="submit">
+              <span>Entrar</span>
+            </button>
+          </form>
+          <p class="auth-error" data-auth-error="login" role="alert" aria-live="polite" hidden></p>
+        </div>
+        <div
+          class="auth-section"
+          data-auth-section="register"
+          role="tabpanel"
+          id="auth-panel-register"
+          aria-labelledby="auth-tab-register"
+          aria-hidden="true"
+          hidden
+        >
+          <form class="auth-form" data-auth-form="register">
+            <label class="auth-field">
+              <span>Email</span>
+              <input type="email" name="email" autocomplete="email" placeholder="nome@exemplo.com" required />
+            </label>
+            <label class="auth-field">
+              <span>Senha</span>
+              <input
+                type="password"
+                name="password"
+                autocomplete="new-password"
+                minlength="6"
+                required
+                placeholder="Crie uma senha segura"
+              />
+              <small class="auth-helper">Mínimo de 6 caracteres.</small>
+            </label>
+            <button class="btn btn-primary" type="submit">
+              <span>Criar conta</span>
+            </button>
+          </form>
+          <p class="auth-error" data-auth-error="register" role="alert" aria-live="polite" hidden></p>
+        </div>
+      </div>
+      <div class="auth-divider"><span>ou</span></div>
+      <button class="btn btn-google" type="button" data-google-login>
+        <span class="btn-icon">G</span>
+        <span>Entrar com Google</span>
+      </button>
+      <p class="auth-footer">Ao continuar você concorda com a sincronização dos seus projetos no Firebase.</p>
     </div>
 
     <script>

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,16 +1,30 @@
 // src/auth.ts
-import { auth, provider, signInWithPopup, signOut, onAuthStateChanged } from './firebase';
+import {
+  auth,
+  provider,
+  signInWithPopup,
+  signOut,
+  onAuthStateChanged,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+} from './firebase';
 import type { User } from 'firebase/auth';
 
 let _user: User | null = null;
 export function getUser(){ return _user; }
 
-export async function login() {
-  try {
-    await signInWithPopup(auth, provider);
-  } catch (e) {
-    console.error(e);
-  }
+export async function loginWithGoogle() {
+  return signInWithPopup(auth, provider);
+}
+
+export const login = loginWithGoogle;
+
+export async function loginWithEmail(email: string, password: string) {
+  return signInWithEmailAndPassword(auth, email, password);
+}
+
+export async function registerWithEmail(email: string, password: string) {
+  return createUserWithEmailAndPassword(auth, email, password);
 }
 
 export async function logout() {

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,7 +1,14 @@
 // src/firebase.ts
 import { initializeApp, type FirebaseApp } from 'firebase/app';
 import {
-  getAuth, GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged, type Auth
+  getAuth,
+  GoogleAuthProvider,
+  signInWithPopup,
+  signOut,
+  onAuthStateChanged,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  type Auth
 } from 'firebase/auth';
 import {
   getFirestore, type Firestore,
@@ -37,7 +44,12 @@ export { storageRef as ref, storageRef as sRef };
 
 // Re-exports (pra importar tudo só de './firebase')
 export {
-  GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged,
+  GoogleAuthProvider,
+  signInWithPopup,
+  signOut,
+  onAuthStateChanged,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
   collection, doc, getDoc, getDocs, setDoc, addDoc, updateDoc, deleteDoc, serverTimestamp,
   uploadBytes, getDownloadURL, deleteObject,
 };

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -1,4 +1,10 @@
-import { auth, provider, signInWithPopup, onAuthStateChanged } from './firebase';
+import { auth, onAuthStateChanged } from './firebase';
+import { loginWithEmail, loginWithGoogle, registerWithEmail } from './auth';
+
+type AuthMode = 'login' | 'register';
+
+const isAuthMode = (value: string | undefined): value is AuthMode =>
+  value === 'login' || value === 'register';
 
 const selectors = ['#btn-login', '[data-login-button]'];
 const loginTargets = new Set<HTMLElement>();
@@ -9,17 +15,269 @@ for (const selector of selectors) {
   });
 }
 
-const handleLoginClick = async (event: Event) => {
-  event.preventDefault();
-  try {
-    await signInWithPopup(auth, provider);
-  } catch (e) {
-    console.error(e);
+const loginModal = document.querySelector<HTMLElement>('[data-login-modal]');
+const loginBackdrop = document.querySelector<HTMLElement>('[data-login-backdrop]');
+const modeButtons = Array.from(
+  document.querySelectorAll<HTMLButtonElement>('[data-auth-mode]')
+);
+const authSections = new Map<AuthMode, HTMLElement>();
+const authForms = new Map<AuthMode, HTMLFormElement>();
+const errorOutputs = new Map<AuthMode, HTMLElement>();
+let currentMode: AuthMode = 'login';
+
+document
+  .querySelectorAll<HTMLElement>('[data-auth-section]')
+  .forEach((section) => {
+    const mode = section.dataset.authSection;
+    if (isAuthMode(mode)) {
+      authSections.set(mode, section);
+    }
+  });
+
+document.querySelectorAll<HTMLFormElement>('[data-auth-form]').forEach((form) => {
+  const mode = form.dataset.authForm;
+  if (isAuthMode(mode)) {
+    authForms.set(mode, form);
   }
+});
+
+document.querySelectorAll<HTMLElement>('[data-auth-error]').forEach((output) => {
+  const mode = output.dataset.authError;
+  if (isAuthMode(mode)) {
+    errorOutputs.set(mode, output);
+  }
+});
+
+const clearErrors = (mode?: AuthMode) => {
+  if (mode) {
+    const output = errorOutputs.get(mode);
+    if (output) {
+      output.textContent = '';
+      output.setAttribute('hidden', '');
+    }
+    return;
+  }
+
+  for (const output of errorOutputs.values()) {
+    output.textContent = '';
+    output.setAttribute('hidden', '');
+  }
+};
+
+const showError = (mode: AuthMode, message: string) => {
+  const output = errorOutputs.get(mode);
+  if (!output) return;
+  if (message) {
+    output.textContent = message;
+    output.removeAttribute('hidden');
+  } else {
+    output.textContent = '';
+    output.setAttribute('hidden', '');
+  }
+};
+
+const setButtonLoading = (button: HTMLButtonElement | null, loading: boolean) => {
+  if (!button) return;
+
+  if (loading) {
+    button.dataset.loading = 'true';
+    button.disabled = true;
+    button.setAttribute('aria-busy', 'true');
+  } else {
+    delete button.dataset.loading;
+    button.disabled = false;
+    button.removeAttribute('aria-busy');
+  }
+};
+
+const focusFirstField = (mode: AuthMode) => {
+  if (!loginModal) return;
+  const field = loginModal.querySelector<HTMLInputElement>(
+    `[data-auth-section="${mode}"] input[type="email"]`
+  );
+  if (field) {
+    window.setTimeout(() => field.focus(), 0);
+  }
+};
+
+const setAuthMode = (mode: AuthMode, { focusField = true } = {}) => {
+  currentMode = mode;
+  loginModal?.setAttribute('data-auth-mode', mode);
+
+  modeButtons.forEach((button) => {
+    const isActive = button.dataset.authMode === mode;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    button.setAttribute('tabindex', isActive ? '0' : '-1');
+  });
+
+  authSections.forEach((section, sectionMode) => {
+    const isActive = sectionMode === mode;
+    section.toggleAttribute('hidden', !isActive);
+    section.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+  });
+
+  clearErrors();
+  if (focusField) {
+    focusFirstField(mode);
+  }
+};
+
+const showLoginModal = (mode: AuthMode = 'login') => {
+  if (!loginModal || !loginBackdrop) return;
+  loginModal.hidden = false;
+  loginModal.setAttribute('aria-hidden', 'false');
+  loginBackdrop.hidden = false;
+  loginBackdrop.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('auth-modal-open');
+  setAuthMode(mode);
+};
+
+const hideLoginModal = () => {
+  if (!loginModal || !loginBackdrop) return;
+  loginModal.hidden = true;
+  loginModal.setAttribute('aria-hidden', 'true');
+  loginBackdrop.hidden = true;
+  loginBackdrop.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('auth-modal-open');
+  clearErrors();
+  authForms.forEach((form) => form.reset());
+};
+
+const formatFirebaseError = (error: unknown) => {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = String((error as { code?: string }).code ?? '');
+    switch (code) {
+      case 'auth/invalid-email':
+        return 'Informe um email válido para continuar.';
+      case 'auth/missing-password':
+      case 'auth/weak-password':
+        return 'A senha precisa ter pelo menos 6 caracteres.';
+      case 'auth/email-already-in-use':
+        return 'Este email já possui cadastro. Tente fazer login.';
+      case 'auth/invalid-credential':
+      case 'auth/user-not-found':
+      case 'auth/wrong-password':
+        return 'Não foi possível encontrar uma conta com essas credenciais.';
+      case 'auth/popup-closed-by-user':
+      case 'auth/cancelled-popup-request':
+        return '';
+      default:
+        return 'Não foi possível completar a solicitação. Tente novamente.';
+    }
+  }
+  return 'Não foi possível completar a solicitação. Tente novamente.';
+};
+
+const validateCredentials = (mode: AuthMode, email: string, password: string) => {
+  if (!email) {
+    showError(mode, 'Informe um email válido para continuar.');
+    return false;
+  }
+  if (!password || password.length < 6) {
+    showError(mode, 'A senha precisa ter pelo menos 6 caracteres.');
+    return false;
+  }
+  return true;
+};
+
+const handleAuthFormSubmit = async (event: SubmitEvent) => {
+  event.preventDefault();
+  const form = event.currentTarget as HTMLFormElement;
+  const mode = form.dataset.authForm;
+  if (!isAuthMode(mode)) return;
+
+  clearErrors(mode);
+
+  const formData = new FormData(form);
+  const email = String(formData.get('email') ?? '').trim();
+  const password = String(formData.get('password') ?? '').trim();
+
+  if (!validateCredentials(mode, email, password)) {
+    return;
+  }
+
+  const submitButton = form.querySelector<HTMLButtonElement>('button[type="submit"]');
+  setButtonLoading(submitButton, true);
+
+  try {
+    if (mode === 'login') {
+      await loginWithEmail(email, password);
+    } else {
+      await registerWithEmail(email, password);
+    }
+    form.reset();
+    hideLoginModal();
+  } catch (error) {
+    console.error(error);
+    const message = formatFirebaseError(error);
+    if (message) {
+      showError(mode, message);
+    }
+  } finally {
+    setButtonLoading(submitButton, false);
+  }
+};
+
+authForms.forEach((form) => {
+  form.addEventListener('submit', handleAuthFormSubmit);
+});
+
+const handleLoginClick = (event: Event) => {
+  event.preventDefault();
+  const element = event.currentTarget as HTMLElement;
+  const mode = element.dataset.authOpenMode;
+  showLoginModal(isAuthMode(mode) ? mode : 'login');
 };
 
 loginTargets.forEach((element) => {
   element.addEventListener('click', handleLoginClick);
+});
+
+const closeButtons = document.querySelectorAll<HTMLElement>('[data-close-login-modal]');
+closeButtons.forEach((button) => {
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    hideLoginModal();
+  });
+});
+
+loginBackdrop?.addEventListener('click', () => hideLoginModal());
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && !loginModal?.hidden) {
+    hideLoginModal();
+  }
+});
+
+modeButtons.forEach((button) => {
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    const mode = (event.currentTarget as HTMLButtonElement).dataset.authMode;
+    if (isAuthMode(mode)) {
+      setAuthMode(mode);
+    }
+  });
+});
+
+const googleButton = document.querySelector<HTMLButtonElement>('[data-google-login]');
+
+googleButton?.addEventListener('click', async (event) => {
+  event.preventDefault();
+  setButtonLoading(googleButton, true);
+  clearErrors(currentMode);
+  try {
+    await loginWithGoogle();
+    hideLoginModal();
+  } catch (error) {
+    console.error(error);
+    const message = formatFirebaseError(error);
+    if (message) {
+      showError(currentMode, message);
+    }
+  } finally {
+    setButtonLoading(googleButton, false);
+  }
 });
 
 onAuthStateChanged(auth, (user) => {


### PR DESCRIPTION
## Summary
- export Firebase helpers for email/password authentication alongside Google sign-in
- implement a landing-page modal that supports Google login plus email/password login and account creation
- refresh landing copy and styles to surface the new authentication options

## Testing
- npx tsc --noEmit
- npm run build *(fails: optional @rollup/rollup-linux-x64-gnu binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3ba86c4c8326a3bbb71d84490baa