### PR TITLE
Scope feedback writes under user document

### DIFF
--- a/src/report.ts
+++ b/src/report.ts
@@ -177,7 +177,7 @@ export function initReportUI() {
 
     try {
       setLoading(true);
-      await addDoc(collection(db, 'reports'), payload);
+      await addDoc(collection(db, 'users', user.uid, 'reports'), payload);
       setStatus('Obrigado! Sua contribuição foi enviada.', 'success');
       form.reset();
       window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- write feedback entries into each user's reports subcollection to match Firestore security rules

## Testing
- npm run build
- Attempted manual feedback submission (fails: permission denied for newly registered account)

------
https://chatgpt.com/codex/tasks/task_e_68cc98cabb4c8326aac5854b67477512