### PR TITLE
Scope feedback writes under user document

### DIFF
--- a/src/report.ts
+++ b/src/report.ts
@@ -1,4 +1,4 @@
-import { db, collection, addDoc, serverTimestamp } from './firebase';
+import { db, collection, doc, addDoc, setDoc, serverTimestamp } from './firebase';
 import { getUser } from './auth';
 
 
@@ -166,18 +166,31 @@ export function initReportUI() {
       return;
     }
 
-    const payload = {
-      uid: user.uid,
-      message,
-      createdAt: serverTimestamp(),
-      source: 'app-report',
-      userEmail: user.email ?? null,
-      userName: user.displayName ?? null,
-    };
-
     try {
       setLoading(true);
-      await addDoc(collection(db, 'reports'), payload);
+      const userDocRef = doc(db, 'users', user.uid);
+      const reportsCollection = collection(userDocRef, 'reports');
+      const payload = {
+        uid: user.uid,
+        message,
+        createdAt: serverTimestamp(),
+        source: 'app-report',
+        userEmail: user.email ?? null,
+        userName: user.displayName ?? null,
+      };
+
+      await setDoc(
+        userDocRef,
+        {
+          uid: user.uid,
+          email: user.email ?? null,
+          displayName: user.displayName ?? null,
+          lastFeedbackAt: serverTimestamp(),
+        },
+        { merge: true }
+      );
+
+      await addDoc(reportsCollection, payload);
       setStatus('Obrigado! Sua contribuição foi enviada.', 'success');
       form.reset();
       window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- write feedback entries into each user's reports subcollection to match Firestore security rules
- ensure the parent user document is merged with basic metadata before saving reports so rules that expect the doc to exist permit the write

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc98cabb4c8326aac5854b67477512