### PR TITLE
Persist uploaded project audio in Firebase

### DIFF
--- a/src/audio.ts
+++ b/src/audio.ts
@@ -10,6 +10,9 @@ let recDest: MediaStreamAudioDestinationNode | null = null;
 export let audioBuffer: AudioBuffer | null = null;
 let audioSourceNode: AudioBufferSourceNode | null = null;
 let waveformData: number[] | null = null;
+let audioFileBlob: Blob | null = null;
+let audioFileName: string | null = null;
+let audioFileContentType: string | null = null;
 
 
 
@@ -19,6 +22,23 @@ export function getAudioSource() { return audioSourceNode; }
 export function setAudioSource(n: AudioBufferSourceNode | null) { audioSourceNode = n; }
 export function getWaveformData() { return waveformData; }
 export function setWaveformData(d: number[] | null){ waveformData = d; }
+export function getAudioFileBlob(): Blob | null { return audioFileBlob; }
+export function getAudioFileName(): string | null { return audioFileName; }
+export function getAudioFileContentType(): string | null { return audioFileContentType; }
+export function setAudioStatusMessage(msg: string) {
+  if (audioStatusEl) audioStatusEl.textContent = msg;
+}
+
+function updateAudioStatus(durationSec?: number) {
+  if (!audioStatusEl) return;
+  if (audioBuffer && audioFileName) {
+    const trimmedName = audioFileName.length > 32 ? `${audioFileName.slice(0, 29)}…` : audioFileName;
+    const durationText = durationSec !== undefined ? ` (${durationSec.toFixed(1)}s)` : '';
+    audioStatusEl.textContent = `Áudio: ${trimmedName}${durationText}`;
+  } else {
+    audioStatusEl.textContent = 'Sem áudio';
+  }
+}
 export function getAudioContext(): AudioContext {
   if (!audioContext) audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
   return audioContext;
@@ -79,30 +99,68 @@ export function initAudioUI() {
     document.addEventListener('mouseup', onUp);
     audioTrackEl.dispatchEvent(new CustomEvent('scrub-request', { detail: { clientX: e.clientX } }));
   });
+
+  updateAudioStatus();
 }
 
-export function carregarArquivoDeAudio(file: File) {
+async function decodeAndApplyAudio(arrayBuffer: ArrayBuffer, fileName?: string): Promise<void> {
   ensureAudioContext();
   if (!audioContext) return;
-  if (audioStatusEl) audioStatusEl.textContent = 'Processando áudio...';
+  const decoded = await audioContext.decodeAudioData(arrayBuffer.slice(0));
+  audioBuffer = decoded;
+  if (fileName) audioFileName = fileName;
+  updateAudioStatus(audioBuffer.duration);
+  processarAudioParaVisualizacao();
+}
 
-  const reader = new FileReader();
-  reader.onload = (e) => {
-    const arrayBuffer = e.target?.result as ArrayBuffer;
-    audioContext!.decodeAudioData(arrayBuffer).then((decoded) => {
-      audioBuffer = decoded;
-      if (audioStatusEl) {
-        const trimmedName = file.name.length > 32 ? `${file.name.slice(0, 29)}…` : file.name;
-        audioStatusEl.textContent = `Áudio: ${trimmedName} (${audioBuffer.duration.toFixed(1)}s)`;
-      }
+export async function carregarArquivoDeAudio(file: File) {
+  ensureAudioContext();
+  if (!audioContext) return;
+  setAudioStatusMessage('Processando áudio...');
 
-      processarAudioParaVisualizacao();
-    }).catch((err) => {
-      if (audioStatusEl) audioStatusEl.textContent = 'Erro ao carregar áudio';
-      alert('Não foi possível processar este arquivo de áudio. ' + err?.message);
-    });
-  };
-  reader.readAsArrayBuffer(file);
+  try {
+    audioFileBlob = file;
+    audioFileName = file.name;
+    audioFileContentType = file.type || null;
+    const arrayBuffer = await file.arrayBuffer();
+    await decodeAndApplyAudio(arrayBuffer, file.name);
+  } catch (err: any) {
+    clearAudio();
+    setAudioStatusMessage('Erro ao carregar áudio');
+    alert('Não foi possível processar este arquivo de áudio. ' + (err?.message || ''));
+  }
+}
+
+export async function setAudioFromBlob(blob: Blob, options: { fileName?: string; contentType?: string } = {}): Promise<void> {
+  ensureAudioContext();
+  if (!audioContext) return;
+  audioFileBlob = blob;
+  audioFileName = options.fileName || audioFileName || 'Áudio';
+  audioFileContentType = options.contentType || blob.type || audioFileContentType || null;
+  setAudioStatusMessage('Processando áudio...');
+  try {
+    const arrayBuffer = await blob.arrayBuffer();
+    await decodeAndApplyAudio(arrayBuffer, audioFileName || undefined);
+  } catch (err) {
+    console.error('Falha ao decodificar áudio', err);
+    clearAudio();
+    throw err;
+  }
+}
+
+export function clearAudio() {
+  audioBuffer = null;
+  waveformData = null;
+  audioFileBlob = null;
+  audioFileName = null;
+  audioFileContentType = null;
+  updateAudioStatus();
+  const ctx = audioCanvas.getContext('2d');
+  if (ctx) {
+    ctx.clearRect(0, 0, audioCanvas.width, audioCanvas.height);
+  }
+  renderizarTudo(true);
+  requestAnimationFrame(renderizarFaixaAudio);
 }
 // src/audio.ts  (ADICIONE ao final do arquivo ou numa seção adequada)
 let _recDest: MediaStreamAudioDestinationNode | null = null;

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -24,7 +24,7 @@ const cfg = {
   apiKey:            import.meta?.env?.VITE_FIREBASE_API_KEY            ?? "AIzaSyBUd7mOWqTXP3E_dNAs-TXAeF9d_WE5rS4",
   authDomain:        import.meta?.env?.VITE_FIREBASE_AUTH_DOMAIN        ?? "pinaform-a5fec.firebaseapp.com",
   projectId:         import.meta?.env?.VITE_FIREBASE_PROJECT_ID         ?? "pinaform-a5fec",
-  storageBucket:     import.meta?.env?.VITE_FIREBASE_STORAGE_BUCKET     ?? "pinaform-a5fec.firebasestorage.app",
+  storageBucket:     import.meta?.env?.VITE_FIREBASE_STORAGE_BUCKET     ?? "pinaform-a5fec.appspot.com",
   messagingSenderId: import.meta?.env?.VITE_FIREBASE_MESSAGING_SENDER_ID?? "885677342214",
   appId:             import.meta?.env?.VITE_FIREBASE_APP_ID             ?? "1:885677342214:web:fe9f74a1065f0ec9ce4d87",
 };

--- a/src/projects_firebase.ts
+++ b/src/projects_firebase.ts
@@ -1,10 +1,18 @@
 // src/projects_firebase.ts
-import { db as localDb } from './state';
-import { getAudioBuffer } from './audio';
+import { db as localDb, getCurrentProjectId, setCurrentProjectId } from './state';
+import {
+  getAudioBuffer,
+  getAudioFileBlob,
+  getAudioFileContentType,
+  getAudioFileName,
+  setAudioFromBlob,
+  clearAudio,
+  setAudioStatusMessage,
+} from './audio';
 
 import {
   db, st,
-  collection, doc, getDocs, setDoc, serverTimestamp,
+  collection, doc, getDoc, getDocs, setDoc, serverTimestamp,
   sRef, uploadBytes, getDownloadURL, deleteObject
 } from './firebase';
 
@@ -14,24 +22,61 @@ type ProjectMeta = {
   updatedAt: number;
   hasAudio: boolean;
   durationSec: number;
+  audioFileName?: string | null;
+  audioContentType?: string | null;
 };
 
 function now() { return Date.now(); }
+
+const AUDIO_STORAGE_KEY = 'audio.bin';
 
 export async function createNewProjectFirebase(titulo = 'Coreografia'): Promise<string> {
   const id = `p${now()}`;
   localDb.projeto   = { id, titulo };
   localDb.formacoes = [];
+  setCurrentProjectId(id);
+  clearAudio();
   return id;
 }
 
 export async function saveProjectFirebase(projectId?: string): Promise<string> {
   const id = projectId || localDb.projeto?.id || `p${now()}`;
   if (!localDb.projeto) localDb.projeto = { id, titulo: 'Coreografia' };
+  localDb.projeto.id = id;
+  setCurrentProjectId(id);
 
   // 1) estado (JSON) no Storage
   const stateBlob = new Blob([JSON.stringify(localDb)], { type: 'application/json' });
-  await uploadBytes(sRef(st, `projects/${id}/state.json`), stateBlob);
+  try {
+    await uploadBytes(sRef(st, `projects/${id}/state.json`), stateBlob);
+  } catch (err) {
+    console.error('Falha ao salvar estado do projeto no Storage', err);
+    alert('Não foi possível salvar o projeto no Firebase Storage. Verifique as regras de acesso e tente novamente.');
+    throw err;
+  }
+
+  const audioBuffer = getAudioBuffer();
+  const audioBlob = getAudioFileBlob();
+  const audioFileName = getAudioFileName();
+  const audioContentType = getAudioFileContentType();
+  const audioRef = sRef(st, `projects/${id}/${AUDIO_STORAGE_KEY}`);
+
+  if (audioBuffer && audioBlob) {
+    try {
+      await uploadBytes(audioRef, audioBlob, audioContentType ? { contentType: audioContentType } : undefined);
+    } catch (err) {
+      console.error('Falha ao enviar áudio do projeto', err);
+      alert('Não foi possível salvar o áudio do projeto no Firebase Storage. Verifique as regras de acesso e tente novamente.');
+      throw err;
+    }
+  } else {
+    try {
+      await deleteObject(audioRef);
+    } catch (err: any) {
+      // ignora se não existir
+      if (err?.code !== 'storage/object-not-found') console.warn('Falha ao remover áudio do projeto', err);
+    }
+  }
 
   // 2) metadados no Firestore
   const durationSec = (localDb.formacoes || [])
@@ -41,8 +86,10 @@ export async function saveProjectFirebase(projectId?: string): Promise<string> {
     id,
     titulo: localDb.projeto.titulo || 'Coreografia',
     updatedAt: now(),
-    hasAudio: !!getAudioBuffer(),
-    durationSec
+    hasAudio: !!audioBuffer,
+    durationSec,
+    audioFileName: audioBuffer ? (audioFileName || null) : null,
+    audioContentType: audioBuffer ? (audioContentType || null) : null,
   };
 
   await setDoc(doc(db, 'projects', id), { ...meta, updatedAtTS: serverTimestamp() }, { merge: true });
@@ -58,14 +105,57 @@ export async function listProjectsFirebase(): Promise<Array<{id:string; titulo:s
 }
 
 export async function openProjectFirebase(id: string): Promise<void> {
-  const url = await getDownloadURL(sRef(st, `projects/${id}/state.json`));
-  const json = await (await fetch(url)).json();
-  Object.assign(localDb, json);
+  setCurrentProjectId(id);
+  const requestId = id;
+  clearAudio();
+
+  try {
+    const [stateUrl, metaSnap] = await Promise.all([
+      getDownloadURL(sRef(st, `projects/${id}/state.json`)),
+      getDoc(doc(db, 'projects', id)).catch(() => null),
+    ]);
+
+    if (getCurrentProjectId() !== requestId) {
+      return;
+    }
+
+    const json = await (await fetch(stateUrl)).json();
+    Object.assign(localDb, json);
+
+    if (getCurrentProjectId() !== requestId) {
+      return;
+    }
+
+    const meta = metaSnap?.exists() ? (metaSnap.data() as ProjectMeta) : null;
+    if (meta?.hasAudio) {
+      try {
+        setAudioStatusMessage('Carregando áudio...');
+        const audioUrl = await getDownloadURL(sRef(st, `projects/${id}/${AUDIO_STORAGE_KEY}`));
+        if (getCurrentProjectId() !== requestId) return;
+        const blob = await (await fetch(audioUrl)).blob();
+        if (getCurrentProjectId() !== requestId) return;
+        await setAudioFromBlob(blob, {
+          fileName: meta.audioFileName || undefined,
+          contentType: meta.audioContentType || blob.type || undefined,
+        });
+      } catch (err) {
+        console.error('Falha ao carregar áudio do projeto', err);
+        clearAudio();
+      }
+    }
+  } catch (err) {
+    if (getCurrentProjectId() === requestId) {
+      console.error('Falha ao carregar projeto do Firebase', err);
+      alert('Não foi possível carregar o projeto selecionado. Verifique as permissões do Firebase Storage e tente novamente.');
+      throw err;
+    }
+  }
 }
 
 export async function deleteProjectFirebase(id: string): Promise<void> {
   await Promise.allSettled([
     deleteObject(sRef(st, `projects/${id}/state.json`)),
+    deleteObject(sRef(st, `projects/${id}/${AUDIO_STORAGE_KEY}`)),
   ]);
   // Se quiser, apague o doc:
   // await deleteDoc(doc(db, 'projects', id));


### PR DESCRIPTION
## Summary
- add audio helpers to track the current blob, metadata, loading status and clearing behaviour when switching projects
- upload project audio blobs to Firebase Storage, persist metadata, and restore audio when opening a saved project
- fix the Firebase Storage bucket configuration, surface storage upload/download failures, and ignore stale audio loads when switching projects quickly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd3a7a40d48326be096b99fe442702