### PR TITLE
Improve audio state cleanup and Firebase error visibility

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -19,12 +19,25 @@ import {
   ref as storageRef, uploadBytes, getDownloadURL, deleteObject
 } from 'firebase/storage';
 
+const DEFAULT_PROJECT_ID = "pinaform-a5fec";
+
+function sanitizeBucketName(raw?: string | null): string | undefined {
+  if (!raw) return undefined;
+  return raw.replace(/^gs:\/\//i, '').trim() || undefined;
+}
+
+const envProjectId = import.meta?.env?.VITE_FIREBASE_PROJECT_ID ?? null;
+const projectId = (envProjectId && `${envProjectId}`.trim()) || DEFAULT_PROJECT_ID;
+
+const envBucket = sanitizeBucketName(import.meta?.env?.VITE_FIREBASE_STORAGE_BUCKET ?? null);
+const storageBucket = envBucket || `${projectId}.appspot.com`;
+
 // Variáveis de ambiente (ou usa os defaults abaixo)
 const cfg = {
   apiKey:            import.meta?.env?.VITE_FIREBASE_API_KEY            ?? "AIzaSyBUd7mOWqTXP3E_dNAs-TXAeF9d_WE5rS4",
-  authDomain:        import.meta?.env?.VITE_FIREBASE_AUTH_DOMAIN        ?? "pinaform-a5fec.firebaseapp.com",
-  projectId:         import.meta?.env?.VITE_FIREBASE_PROJECT_ID         ?? "pinaform-a5fec",
-  storageBucket:     import.meta?.env?.VITE_FIREBASE_STORAGE_BUCKET     ?? "pinaform-a5fec.firebasestorage.app",
+  authDomain:        import.meta?.env?.VITE_FIREBASE_AUTH_DOMAIN        ?? `${projectId}.firebaseapp.com`,
+  projectId,
+  storageBucket,
   messagingSenderId: import.meta?.env?.VITE_FIREBASE_MESSAGING_SENDER_ID?? "885677342214",
   appId:             import.meta?.env?.VITE_FIREBASE_APP_ID             ?? "1:885677342214:web:fe9f74a1065f0ec9ce4d87",
 };

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -1,22 +1,58 @@
 // src/persist.ts
 
-import { db } from './firebase';
+import { db, st, sRef, uploadBytes, getDownloadURL, deleteObject } from './firebase';
 import { getUser } from './auth';
 import {
-  collection, addDoc, setDoc, getDocs, doc, getDoc,
+  collection, setDoc, getDocs, doc, getDoc,
   serverTimestamp, query, orderBy
 } from 'firebase/firestore';
 import * as State from './state';
 import { setCurrentProjectId, getCurrentProjectId } from './state';
 import { renderizarTudo } from './timeline';
 import { btnSalvarProjeto, btnNovoProjeto, selProjeto } from './dom';
+import {
+  clearAudio,
+  getAudioBuffer,
+  getAudioFileBlob,
+  getAudioFileContentType,
+  getAudioFileName,
+  refreshAudioStatusLabel,
+  setAudioFromBlob,
+  setAudioStatusMessage,
+} from './audio';
 
 type ProjetoDoc = {
   title: string;
   updatedAt: any;
   createdAt: any;
   db: any; // snapshot do State.db
+  hasAudio?: boolean;
+  audioFileName?: string | null;
+  audioContentType?: string | null;
+  audioUpdatedAt?: any;
 };
+
+const AUDIO_STORAGE_KEY = 'audio.bin';
+
+function projectAudioRef(userId: string, projectId: string) {
+  return sRef(st, `users/${userId}/projects/${projectId}/${AUDIO_STORAGE_KEY}`);
+}
+
+function describeFirebaseError(err: unknown): string {
+  if (!err) return 'Erro desconhecido.';
+  if (typeof err === 'string') return err;
+  const anyErr = err as { code?: string; message?: string };
+  const code = anyErr?.code ? `${anyErr.code}` : '';
+  const msg = anyErr?.message ? `${anyErr.message}` : '';
+  if (code && msg) return `${code} - ${msg}`;
+  if (code) return code;
+  if (msg) return msg;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
 
 export async function listProjects(): Promise<{id:string; title:string}[]> {
   const user = getUser();
@@ -30,45 +66,112 @@ export async function listProjects(): Promise<{id:string; title:string}[]> {
 export async function loadProject(projectId: string) {
   const user = getUser();
   if (!user) throw new Error('Não autenticado.');
+  const requestId = projectId;
+  setCurrentProjectId(requestId);
+  localStorage.setItem('lastProjectId', requestId);
+  clearAudio();
+
   const ref = doc(db, 'users', user.uid, 'projects', projectId);
   const snap = await getDoc(ref);
   if (!snap.exists()) throw new Error('Projeto não encontrado');
   const data = snap.data() as ProjetoDoc;
 
+  if (getCurrentProjectId() !== requestId) return;
+
   // aplica no State.db
   State.db.projeto = data.db?.projeto ?? State.db.projeto;
+  State.db.projeto.id = projectId;
   State.db.formacoes = Array.isArray(data.db?.formacoes) ? data.db.formacoes : [];
-
-  setCurrentProjectId(projectId);
-  localStorage.setItem('lastProjectId', projectId);
 
   document.dispatchEvent(new CustomEvent('db-changed', { detail: { reason: 'load-project' }}));
   renderizarTudo(true);
+
+  if (data.hasAudio) {
+    try {
+      setAudioStatusMessage('Carregando áudio...');
+      const audioUrl = await getDownloadURL(projectAudioRef(user.uid, projectId));
+      if (getCurrentProjectId() !== requestId) return;
+      const blob = await (await fetch(audioUrl)).blob();
+      if (getCurrentProjectId() !== requestId) return;
+      await setAudioFromBlob(blob, {
+        fileName: data.audioFileName || undefined,
+        contentType: data.audioContentType || blob.type || undefined,
+      });
+    } catch (err: any) {
+      if (getCurrentProjectId() === requestId) {
+        console.error('Falha ao carregar áudio do projeto', err);
+        const detail = describeFirebaseError(err);
+        alert(`Não foi possível carregar o áudio deste projeto.\n${detail}\nVerifique as permissões do Firebase Storage e tente novamente.`);
+        clearAudio();
+      }
+    }
+  }
 }
 
 export async function saveProject(explicitId?: string) {
   const user = getUser();
   if (!user) throw new Error('Não autenticado.');
 
+  const colRef = collection(db, 'users', user.uid, 'projects');
+  let targetId = explicitId || getCurrentProjectId() || State.db.projeto?.id || null;
+  const docRef = targetId ? doc(colRef, targetId) : doc(colRef);
+  if (!targetId) targetId = docRef.id;
+
+  // garante que o snapshot salvo tenha o ID correto
+  State.db.projeto.id = targetId;
+  if (!State.db.projeto.titulo) State.db.projeto.titulo = 'Projeto sem título';
+
+  const audioBuffer = getAudioBuffer();
+  const audioBlob = getAudioFileBlob();
+  const audioFileName = getAudioFileName();
+  const audioContentType = getAudioFileContentType();
+  const hasAudio = !!audioBuffer && !!audioBlob;
+
   const payload: ProjetoDoc = {
     title: State.db?.projeto?.titulo || 'Projeto sem título',
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
     db: JSON.parse(JSON.stringify(State.db)),
+    hasAudio,
+    audioFileName: hasAudio ? (audioFileName || null) : null,
+    audioContentType: hasAudio ? (audioContentType || null) : null,
+    audioUpdatedAt: hasAudio ? serverTimestamp() : null,
   };
 
-  const colRef = collection(db, 'users', user.uid, 'projects');
-
-  if (explicitId) {
-    const ref = doc(db, 'users', user.uid, 'projects', explicitId);
-    await setDoc(ref, payload, { merge: true });
-    setCurrentProjectId(explicitId);
-    localStorage.setItem('lastProjectId', explicitId);
+  const audioRef = projectAudioRef(user.uid, targetId);
+  if (hasAudio && audioBlob) {
+    try {
+      setAudioStatusMessage('Enviando áudio para o Firebase...');
+      await uploadBytes(
+        audioRef,
+        audioBlob,
+        audioContentType ? { contentType: audioContentType } : undefined,
+      );
+      refreshAudioStatusLabel();
+    } catch (err) {
+      console.error('Falha ao enviar áudio do projeto', err);
+      const detail = describeFirebaseError(err);
+      setAudioStatusMessage('Erro ao salvar áudio');
+      alert(`Não foi possível salvar o áudio do projeto no Firebase Storage.\n${detail}\nVerifique as regras de acesso e tente novamente.`);
+      throw err;
+    }
   } else {
-    const result = await addDoc(colRef, payload);
-    setCurrentProjectId(result.id);
-    localStorage.setItem('lastProjectId', result.id);
+    try {
+      await deleteObject(audioRef);
+    } catch (err: any) {
+      if (err?.code !== 'storage/object-not-found') {
+        const detail = describeFirebaseError(err);
+        console.warn('Falha ao remover áudio do projeto', err);
+        setAudioStatusMessage('Erro ao remover áudio');
+        alert(`Não foi possível remover o áudio associado a este projeto.\n${detail}\nVerifique as permissões do Firebase Storage e tente novamente.`);
+      }
+    }
   }
+
+  await setDoc(docRef, payload, { merge: true });
+
+  setCurrentProjectId(targetId);
+  localStorage.setItem('lastProjectId', targetId);
 }
 
 export async function createNewProject(title = 'Novo projeto') {
@@ -76,6 +179,7 @@ export async function createNewProject(title = 'Novo projeto') {
   State.db.projeto.titulo = title;
   State.db.formacoes = [];
   setCurrentProjectId(null);
+  clearAudio();
 
   document.dispatchEvent(new CustomEvent('db-changed', { detail: { reason: 'new-project' }}));
   renderizarTudo(true);

--- a/src/projects_firebase.ts
+++ b/src/projects_firebase.ts
@@ -1,10 +1,19 @@
 // src/projects_firebase.ts
-import { db as localDb } from './state';
-import { getAudioBuffer } from './audio';
+import { db as localDb, getCurrentProjectId, setCurrentProjectId } from './state';
+import {
+  getAudioBuffer,
+  getAudioFileBlob,
+  getAudioFileContentType,
+  getAudioFileName,
+  refreshAudioStatusLabel,
+  setAudioFromBlob,
+  clearAudio,
+  setAudioStatusMessage,
+} from './audio';
 
 import {
   db, st,
-  collection, doc, getDocs, setDoc, serverTimestamp,
+  collection, doc, getDoc, getDocs, setDoc, serverTimestamp,
   sRef, uploadBytes, getDownloadURL, deleteObject
 } from './firebase';
 
@@ -14,24 +23,90 @@ type ProjectMeta = {
   updatedAt: number;
   hasAudio: boolean;
   durationSec: number;
+  audioFileName?: string | null;
+  audioContentType?: string | null;
 };
 
 function now() { return Date.now(); }
+
+const AUDIO_STORAGE_KEY = 'audio.bin';
 
 export async function createNewProjectFirebase(titulo = 'Coreografia'): Promise<string> {
   const id = `p${now()}`;
   localDb.projeto   = { id, titulo };
   localDb.formacoes = [];
+  setCurrentProjectId(id);
+  clearAudio();
   return id;
+}
+
+function describeFirebaseError(err: unknown): string {
+  if (!err) return 'Erro desconhecido.';
+  if (typeof err === 'string') return err;
+  const anyErr = err as { code?: string; message?: string };
+  const code = anyErr?.code ? `${anyErr.code}` : '';
+  const msg = anyErr?.message ? `${anyErr.message}` : '';
+  if (code && msg) return `${code} - ${msg}`;
+  if (code) return code;
+  if (msg) return msg;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
 }
 
 export async function saveProjectFirebase(projectId?: string): Promise<string> {
   const id = projectId || localDb.projeto?.id || `p${now()}`;
   if (!localDb.projeto) localDb.projeto = { id, titulo: 'Coreografia' };
+  localDb.projeto.id = id;
+  setCurrentProjectId(id);
 
   // 1) estado (JSON) no Storage
   const stateBlob = new Blob([JSON.stringify(localDb)], { type: 'application/json' });
-  await uploadBytes(sRef(st, `projects/${id}/state.json`), stateBlob);
+  try {
+    await uploadBytes(sRef(st, `projects/${id}/state.json`), stateBlob);
+  } catch (err) {
+    console.error('Falha ao salvar estado do projeto no Storage', err);
+    alert('Não foi possível salvar o projeto no Firebase Storage. Verifique as regras de acesso e tente novamente.');
+    throw err;
+  }
+
+  const projectAudioBuffer = getAudioBuffer();
+  const projectAudioBlob = getAudioFileBlob();
+  const projectAudioFileName = getAudioFileName();
+  const projectAudioContentType = getAudioFileContentType();
+  const audioRef = sRef(st, `projects/${id}/${AUDIO_STORAGE_KEY}`);
+
+  if (projectAudioBuffer && projectAudioBlob) {
+    try {
+      setAudioStatusMessage('Enviando áudio para o Firebase...');
+      await uploadBytes(
+        audioRef,
+        projectAudioBlob,
+        projectAudioContentType ? { contentType: projectAudioContentType } : undefined,
+      );
+      refreshAudioStatusLabel();
+    } catch (err) {
+      console.error('Falha ao enviar áudio do projeto', err);
+      const detail = describeFirebaseError(err);
+      setAudioStatusMessage('Erro ao salvar áudio');
+      alert(`Não foi possível salvar o áudio do projeto no Firebase Storage.\n${detail}\nVerifique as regras de acesso e tente novamente.`);
+      throw err;
+    }
+  } else {
+    try {
+      await deleteObject(audioRef);
+    } catch (err: any) {
+      // ignora se não existir
+      if (err?.code !== 'storage/object-not-found') {
+        const detail = describeFirebaseError(err);
+        console.warn('Falha ao remover áudio do projeto', err);
+        setAudioStatusMessage('Erro ao remover áudio');
+        alert(`Não foi possível remover o áudio associado a este projeto.\n${detail}\nVerifique as permissões do Firebase Storage e tente novamente.`);
+      }
+    }
+  }
 
   // 2) metadados no Firestore
   const durationSec = (localDb.formacoes || [])
@@ -41,8 +116,10 @@ export async function saveProjectFirebase(projectId?: string): Promise<string> {
     id,
     titulo: localDb.projeto.titulo || 'Coreografia',
     updatedAt: now(),
-    hasAudio: !!getAudioBuffer(),
-    durationSec
+    hasAudio: !!projectAudioBuffer,
+    durationSec,
+    audioFileName: projectAudioBuffer ? (projectAudioFileName || null) : null,
+    audioContentType: projectAudioBuffer ? (projectAudioContentType || null) : null,
   };
 
   await setDoc(doc(db, 'projects', id), { ...meta, updatedAtTS: serverTimestamp() }, { merge: true });
@@ -58,14 +135,60 @@ export async function listProjectsFirebase(): Promise<Array<{id:string; titulo:s
 }
 
 export async function openProjectFirebase(id: string): Promise<void> {
-  const url = await getDownloadURL(sRef(st, `projects/${id}/state.json`));
-  const json = await (await fetch(url)).json();
-  Object.assign(localDb, json);
+  setCurrentProjectId(id);
+  const requestId = id;
+  clearAudio();
+
+  try {
+    const [stateUrl, metaSnap] = await Promise.all([
+      getDownloadURL(sRef(st, `projects/${id}/state.json`)),
+      getDoc(doc(db, 'projects', id)).catch(() => null),
+    ]);
+
+    if (getCurrentProjectId() !== requestId) {
+      return;
+    }
+
+    const json = await (await fetch(stateUrl)).json();
+    Object.assign(localDb, json);
+
+    if (getCurrentProjectId() !== requestId) {
+      return;
+    }
+
+    const meta = metaSnap?.exists() ? (metaSnap.data() as ProjectMeta) : null;
+    if (meta?.hasAudio) {
+      try {
+        setAudioStatusMessage('Carregando áudio...');
+        const audioUrl = await getDownloadURL(sRef(st, `projects/${id}/${AUDIO_STORAGE_KEY}`));
+        if (getCurrentProjectId() !== requestId) return;
+        const blob = await (await fetch(audioUrl)).blob();
+        if (getCurrentProjectId() !== requestId) return;
+        await setAudioFromBlob(blob, {
+          fileName: meta.audioFileName || undefined,
+          contentType: meta.audioContentType || blob.type || undefined,
+        });
+      } catch (err) {
+        console.error('Falha ao carregar áudio do projeto', err);
+        setAudioStatusMessage('Erro ao carregar áudio');
+        const detail = describeFirebaseError(err);
+        alert(`Não foi possível carregar o áudio deste projeto.\n${detail}\nVerifique as permissões do Firebase Storage e tente novamente.`);
+        clearAudio();
+      }
+    }
+  } catch (err) {
+    if (getCurrentProjectId() === requestId) {
+      console.error('Falha ao carregar projeto do Firebase', err);
+      alert('Não foi possível carregar o projeto selecionado. Verifique as permissões do Firebase Storage e tente novamente.');
+      throw err;
+    }
+  }
 }
 
 export async function deleteProjectFirebase(id: string): Promise<void> {
   await Promise.allSettled([
     deleteObject(sRef(st, `projects/${id}/state.json`)),
+    deleteObject(sRef(st, `projects/${id}/${AUDIO_STORAGE_KEY}`)),
   ]);
   // Se quiser, apague o doc:
   // await deleteDoc(doc(db, 'projects', id));


### PR DESCRIPTION
## Summary
- stop any playing audio node when clearing the timeline and expose a helper to restore the status text after uploads
- surface detailed Firebase Storage error messages while saving, loading, or deleting project audio and refresh the status label after successful uploads
- reuse the improved error messaging in the shared Firebase project helpers so both persistence flows report permission issues consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd3a7a40d48326be096b99fe442702