### PR TITLE
Ensure unauthenticated users return to landing

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -38,14 +38,33 @@ export async function logout() {
   window.location.href = 'landing.html';
 }
 
+function redirectToLanding() {
+  const { pathname } = window.location;
+  if (pathname.endsWith('/landing.html') || pathname.endsWith('/landing')) {
+    return;
+  }
+  window.location.href = 'landing.html';
+}
+
 export function requireAuth() {
+  let receivedAuthEvent = false;
+
   onAuthStateChanged(auth, (u) => {
+    receivedAuthEvent = true;
     _user = u;
     document.dispatchEvent(new CustomEvent('auth-changed', {
       detail: u ? { uid: u.uid } : null
     }));
     if (!u) {
-      window.location.href = 'landing.html';
+      redirectToLanding();
     }
   });
+
+  if (!auth.currentUser) {
+    window.setTimeout(() => {
+      if (!receivedAuthEvent && !getUser()) {
+        redirectToLanding();
+      }
+    }, 2000);
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,15 @@ initReportUI();
 // tenta preencher a combo de projetos quando possível
 setTimeout(refreshProjectListUI, 600);
 
-btnLogout?.addEventListener('click', async () => {
+btnLogout?.addEventListener('click', async (event) => {
+  event.preventDefault();
+  const action = btnLogout?.dataset.authAction;
+
+  if (action === 'login') {
+    window.location.href = 'landing.html';
+    return;
+  }
+
   try {
     await logout();
   } catch (e) {
@@ -31,12 +39,21 @@ btnLogout?.addEventListener('click', async () => {
 
 const updateAuthUI = () => {
   const user = getUser();
-  if (user) {
-    if (btnLogout) btnLogout.style.display = '';
-    if (userBadgeEl) userBadgeEl.textContent = user.displayName || user.email || 'logado';
-  } else {
-    if (btnLogout) btnLogout.style.display = 'none';
-    if (userBadgeEl) userBadgeEl.textContent = 'offline';
+  if (btnLogout) {
+    btnLogout.style.display = '';
+    if (user) {
+      btnLogout.textContent = 'Sair';
+      btnLogout.dataset.authAction = 'logout';
+      btnLogout.setAttribute('aria-label', 'Sair da conta e voltar para a landing');
+    } else {
+      btnLogout.textContent = 'Entrar';
+      btnLogout.dataset.authAction = 'login';
+      btnLogout.setAttribute('aria-label', 'Ir para a tela de login');
+    }
+  }
+
+  if (userBadgeEl) {
+    userBadgeEl.textContent = user ? user.displayName || user.email || 'logado' : 'offline';
   }
 };
 


### PR DESCRIPTION
## Summary
- add a resilient landing-page redirect in the auth guard so unauthenticated sessions cannot stay on the editor
- expose the header action as a login shortcut when no user is present so people can easily access the landing login flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cde7abbb8c8326b3520e40aa03e05d