### PR TITLE
Harden auth guard and landing modal loading

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,7 +10,30 @@ import {
 } from './firebase';
 import type { User } from 'firebase/auth';
 
+type AuthLandingMode = 'login' | 'register';
+
 let _user: User | null = auth.currentUser;
+
+const AUTH_CHANGED_EVENT = 'auth-changed';
+
+const isLandingPath = (pathname: string) =>
+  pathname.endsWith('/landing.html') || pathname.endsWith('/landing');
+
+const buildLandingUrl = (mode: AuthLandingMode = 'login') => {
+  const url = new URL('landing.html', window.location.href);
+  url.searchParams.set('auth', mode);
+  return url.toString();
+};
+
+const emitAuthChange = (user: User | null) => {
+  _user = user;
+  document.dispatchEvent(
+    new CustomEvent(AUTH_CHANGED_EVENT, {
+      detail: user ? { uid: user.uid } : null,
+    }),
+  );
+};
+
 export function getUser() {
   return _user ?? auth.currentUser ?? null;
 }
@@ -29,23 +52,70 @@ export async function registerWithEmail(email: string, password: string) {
   return createUserWithEmailAndPassword(auth, email, password);
 }
 
+export const redirectToLanding = (mode: AuthLandingMode = 'login') => {
+  if (isLandingPath(window.location.pathname)) {
+    const current = new URL(window.location.href);
+    current.searchParams.set('auth', mode);
+    const target = current.toString();
+    if (target !== window.location.href) {
+      window.location.replace(target);
+    }
+    return;
+  }
+
+  window.location.replace(buildLandingUrl(mode));
+};
+
 export async function logout() {
   try {
     await signOut(auth);
-  } catch (e) {
-    console.error(e);
+  } catch (error) {
+    console.error('Erro ao encerrar sessão.', error);
   }
-  window.location.href = 'landing.html';
+
+  redirectToLanding();
 }
 
-export function requireAuth() {
-  onAuthStateChanged(auth, (u) => {
-    _user = u;
-    document.dispatchEvent(new CustomEvent('auth-changed', {
-      detail: u ? { uid: u.uid } : null
-    }));
-    if (!u) {
-      window.location.href = 'landing.html';
+export const requireAuth = () => {
+  let receivedAuthEvent = false;
+  let fallbackTimer: number | undefined;
+
+  const handleAuthState = (user: User | null) => {
+    receivedAuthEvent = true;
+    window.clearTimeout(fallbackTimer);
+    emitAuthChange(user);
+    if (!user) {
+      redirectToLanding();
     }
-  });
-}
+  };
+
+  try {
+    onAuthStateChanged(
+      auth,
+      (user) => handleAuthState(user),
+      (error) => {
+        console.error('Falha ao observar a autenticação.', error);
+        window.clearTimeout(fallbackTimer);
+        if (!receivedAuthEvent && !getUser()) {
+          redirectToLanding();
+        }
+      },
+    );
+  } catch (error) {
+    console.error('Falha ao inicializar a verificação de autenticação.', error);
+    if (!getUser()) {
+      redirectToLanding();
+    }
+    return;
+  }
+
+  emitAuthChange(auth.currentUser ?? null);
+
+  if (!auth.currentUser) {
+    fallbackTimer = window.setTimeout(() => {
+      if (!receivedAuthEvent && !getUser()) {
+        redirectToLanding();
+      }
+    }, 2000);
+  }
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { initPlaybackAndIO } from './playback';
 import { renderizarPalco, renderizarPalcoEmTransicao, renderizarPalcoComFormacao, initBailarinoUI } from './stage'; // <-- ADICIONE initBailarinoUI
 import { setZoom } from './state';
 import { initAudioUI } from './audio';
-import { requireAuth, logout, getUser } from './auth';
+import { requireAuth, logout, getUser, redirectToLanding } from './auth';
 import { initPersistenceUI, refreshProjectListUI } from './persist';
 import { initUI } from './ui';
 import { startRecording, stopRecording } from './record';
@@ -21,7 +21,19 @@ initReportUI();
 // tenta preencher a combo de projetos quando possível
 setTimeout(refreshProjectListUI, 600);
 
-btnLogout?.addEventListener('click', async () => {
+if (btnLogout && !btnLogout.hasAttribute('type')) {
+  btnLogout.type = 'button';
+}
+
+btnLogout?.addEventListener('click', async (event) => {
+  event.preventDefault();
+  const action = btnLogout?.dataset.authAction;
+
+  if (action === 'login') {
+    redirectToLanding();
+    return;
+  }
+
   try {
     await logout();
   } catch (e) {
@@ -31,12 +43,21 @@ btnLogout?.addEventListener('click', async () => {
 
 const updateAuthUI = () => {
   const user = getUser();
-  if (user) {
-    if (btnLogout) btnLogout.style.display = '';
-    if (userBadgeEl) userBadgeEl.textContent = user.displayName || user.email || 'logado';
-  } else {
-    if (btnLogout) btnLogout.style.display = 'none';
-    if (userBadgeEl) userBadgeEl.textContent = 'offline';
+  if (btnLogout) {
+    btnLogout.style.display = '';
+    if (user) {
+      btnLogout.textContent = 'Sair';
+      btnLogout.dataset.authAction = 'logout';
+      btnLogout.setAttribute('aria-label', 'Sair da conta e voltar para a landing');
+    } else {
+      btnLogout.textContent = 'Entrar';
+      btnLogout.dataset.authAction = 'login';
+      btnLogout.setAttribute('aria-label', 'Ir para a tela de login');
+    }
+  }
+
+  if (userBadgeEl) {
+    userBadgeEl.textContent = user ? user.displayName || user.email || 'logado' : 'offline';
   }
 };
 


### PR DESCRIPTION
## Summary
- lazy-load the Firebase auth helpers on the landing page so UI wiring still runs even when Firebase fails to initialise
- show a friendly error when auth modules cannot be loaded and prefetch dependencies whenever the modal opens or an auth tab is selected
- harden the editor auth guard to emit login state updates, catch observer failures, and redirect unauthenticated visitors back to the landing modal with a timed fallback
- allow retryable, typed dynamic imports on the landing page and prefetch auth code when users focus or hover the login entry points so the modal opens ready to authenticate

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cde7abbb8c8326b3520e40aa03e05d