### PR TITLE
Fix TypeScript syntax errors in auth and landing modules

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -122,3 +122,4 @@ export const requireAuth = () => {
     }, 2000);
   }
 
+};

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -387,4 +387,3 @@ if (isAuthMode(initialAuthModeParam)) {
   prefetchAuthDeps();
   showLoginModal(initialAuthModeParam);
 }
-=


### PR DESCRIPTION
## Summary
- close the `requireAuth` function block in `src/auth.ts`
- remove the stray `=` left at the end of `src/landing.ts`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf5665f8708326800c672b21abcdc8