### PR TITLE
Fix Vite base path for relative asset loading

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite'
 import { resolve } from 'path'
 
 export default defineConfig({
+  base: './',
   server: { port: 5173, host: true },
   build: {
     rollupOptions: {


### PR DESCRIPTION
## Summary
- set Vite's base path to a relative URL so built assets resolve correctly when hosted from a subdirectory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d14767ce108326960cfd6f094ce5cf